### PR TITLE
Edit existing user profile partial to include addresses

### DIFF
--- a/app/views/partials/_user_profile.html.erb
+++ b/app/views/partials/_user_profile.html.erb
@@ -34,14 +34,16 @@
     <%= link_to 'Your Orders', user_orders_path, class: 'btn btn-success ml-2 mr-2' %>
   <% end %>
   <% if !admin %>
-    <%= link_to 'Add New Address', '', class: 'btn btn-primary ml-2 mr-2' %>
     <%= link_to 'Edit Your Info', '/profile/edit', class: 'btn btn-primary ml-2 mr-2' %>
     <%= link_to 'Change Your Password', '/profile/edit?info=false', class: 'btn btn-danger ml-2 mr-2' %>
   <% end %>
 </article>
 
 <% if !current_user.admin? %>
-  <h1 class="mt-4 text-center">Your Addresses</h1>
+  <div class="text-center mt-4">
+    <h1>Your Addresses</h1>
+    <%= link_to 'Add New Address', '', class: 'btn btn-primary mt-2 mb-2' %>
+  </div>
   <section class="container-fluid row justify-content-center">
     <section class = "card card-body bg-light m-3 p-4 col-md-3" id= 'address-home'>
       <h2 class="text-center">Home</h2>

--- a/app/views/partials/_user_profile.html.erb
+++ b/app/views/partials/_user_profile.html.erb
@@ -34,7 +34,33 @@
     <%= link_to 'Your Orders', user_orders_path, class: 'btn btn-success ml-2 mr-2' %>
   <% end %>
   <% if !admin %>
+    <%= link_to 'Add New Address', '', class: 'btn btn-primary ml-2 mr-2' %>
     <%= link_to 'Edit Your Info', '/profile/edit', class: 'btn btn-primary ml-2 mr-2' %>
     <%= link_to 'Change Your Password', '/profile/edit?info=false', class: 'btn btn-danger ml-2 mr-2' %>
   <% end %>
 </article>
+
+<% if !current_user.admin? %>
+  <h1 class="mt-4 text-center">Your Addresses</h1>
+  <section class="container-fluid row justify-content-center">
+    <section class = "card card-body bg-light m-3 p-4 col-md-3" id= 'address-home'>
+      <h2 class="text-center">Home</h2>
+      <p>Street: <%= current_user.address %></p>
+      <p>City: <%= current_user.city %></p>
+      <p>State: <%= current_user.state %></p>
+      <p>Zip: <%= current_user.zip %></p>
+      <%= link_to 'Edit', '/profile/edit', class: 'btn btn-primary' %>
+    </section>
+
+    <% @user.addresses.each do |address| %>
+      <section class = "card card-body bg-light m-3 p-4 col-md-3" id= 'address-<%=address.id%>'>
+        <h2 class="text-center"> <%= address.nickname %> </h2>
+        <p>Street: <%= address.street %></p>
+        <p>City: <%= address.city %></p>
+        <p>State: <%= address.state %></p>
+        <p>Zip: <%= address.zip %></p>
+        <%= link_to 'Edit', '', class: 'btn btn-primary' %>
+      </section>
+    <% end %>
+  </section>
+<% end %>

--- a/spec/features/default_user/profile_spec.rb
+++ b/spec/features/default_user/profile_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'As a default user' do
   before :each do
     @user = User.create!(name: "Gmoney", address: "123 Lincoln St", city: "Denver", state: "CO", zip: 23840, email: "test@gmail.com", password: "password123", password_confirmation: "password123")
+    @address_2 = @user.addresses.create!(nickname: 'Work', street: "478 Hanover Blvd", city: "Denver", state: "CO", zip: 80128)
+    @address_3 = @user.addresses.create!(nickname: 'Mom\'s', street: "101 Sixma Ave", city: "Deltona", state: "FL", zip: 32738)
 
     visit '/login'
 
@@ -146,5 +148,50 @@ RSpec.describe 'As a default user' do
     visit '/profile'
 
     expect(page).to_not have_link('Your Orders')
+  end
+
+  it 'shows all currently saved addresses' do
+    visit '/profile'
+
+    within '#address-home' do
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content(@user.city)
+      expect(page).to have_content(@user.state)
+      expect(page).to have_content(@user.zip)
+    end
+
+    within "#address-#{@address_2.id}" do
+      expect(page).to have_content(@address_2.nickname)
+      expect(page).to have_content(@address_2.street)
+      expect(page).to have_content(@address_2.city)
+      expect(page).to have_content(@address_2.state)
+      expect(page).to have_content(@address_2.zip)
+    end
+
+    within "#address-#{@address_3.id}" do
+      expect(page).to have_content(@address_3.nickname)
+      expect(page).to have_content(@address_3.street)
+      expect(page).to have_content(@address_3.city)
+      expect(page).to have_content(@address_3.state)
+      expect(page).to have_content(@address_3.zip)
+    end
+  end
+
+  it 'shows a link to edit each address' do
+    visit '/profile'
+
+    within "#address-#{@address_2.id}" do
+      expect(page).to have_link('Edit')
+    end
+
+    within "#address-#{@address_3.id}" do
+      expect(page).to have_link('Edit')
+    end
+  end
+
+  it 'shows a link to add a new address' do
+    visit '/profile'
+
+    expect(page).to have_link('Add New Address')
   end
 end


### PR DESCRIPTION
- Add feature tests for showing addresses on user profile page, as well as links to create a new address or edit an existing address
- Edit user profile partial to include addresses and links and pass tests
- Use check for `current_user.admin?` to NOT show addresses on admin profile page